### PR TITLE
Fix for febbox files not playing

### DIFF
--- a/src/providers/embeds/febbox/qualities.ts
+++ b/src/providers/embeds/febbox/qualities.ts
@@ -20,6 +20,21 @@ function mapToQuality(quality: FebboxQuality): FebboxQuality | null {
   };
 }
 
+function removeBadUrlParams(url: string): string {
+  const urlObject = new URL(url);
+
+  const urlSearchParams = new URLSearchParams(urlObject.search);
+
+  const keysToKeep = ['KEY1', 'KEY2'];
+  for (const key of Array.from(urlSearchParams.keys())) {
+    if (!keysToKeep.includes(key)) {
+      urlSearchParams.delete(key);
+    }
+  }
+
+  return `${urlObject.origin}${urlObject.pathname}?${urlSearchParams.toString()}`;
+}
+
 export async function getStreamQualities(ctx: ScrapeContext, apiQuery: object) {
   const mediaRes: { list: FebboxQuality[] } = (await sendRequest(ctx, apiQuery)).data;
 
@@ -32,7 +47,7 @@ export async function getStreamQualities(ctx: ScrapeContext, apiQuery: object) {
     if (foundQuality) {
       qualities[quality] = {
         type: 'mp4',
-        url: foundQuality.path,
+        url: removeBadUrlParams(foundQuality.path),
       };
     }
   });


### PR DESCRIPTION
This pull request resolves the febbox mp4 files not playing on the flixquest-api.
Based on the code provided on [movie-web/providers
](https://github.com/movie-web/providers/commit/f4d0a7a05e130651505865471196bbec73fa8ecd)